### PR TITLE
Made templates location independent

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ type RequestContext struct {
 	]
 */
 
-var exePath, err = os.Executable()
+var exePath, _ = os.Executable()
 var exeDir string = filepath.Dir(exePath)
 var templatesDir string = filepath.Join(exeDir, `./templates/`)
 var servicesPath string = filepath.Join(exeDir, `./templates/services.json`)

--- a/main.go
+++ b/main.go
@@ -90,7 +90,10 @@ type RequestContext struct {
 	]
 */
 
-var servicesPath string = `./templates/services.json`
+var exePath, err = os.Executable()
+var exeDir string = filepath.Dir(exePath)
+var templatesDir string = filepath.Join(exeDir, `./templates/`)
+var servicesPath string = filepath.Join(exeDir, `./templates/services.json`)
 var selectedServices []Service
 
 var suffixes = []string{
@@ -116,9 +119,9 @@ var suffixes = []string{
 func loadTemplates() ([]Service, error) {
 	var services []Service
 
-	file, err := os.Open("./templates/services.json")
+	file, err := os.Open(servicesPath)
 	if err != nil {
-		fmt.Println("ERROR: Failed opening file \"./templates/services.json\":", err)
+		fmt.Println("ERROR: Failed opening file \"", servicesPath, "\":", err)
 		return services, err
 	}
 	defer file.Close()
@@ -170,7 +173,7 @@ func updateTemplates(path *string, update bool) *error {
 			fmt.Println("[+] Info: Creating templates directory...")
 
 			// create "templates" directory
-			_ = os.Mkdir(`./templates`, 0700)
+			_ = os.Mkdir(templatesDir, 0700)
 
 			// Create "services.json" file
 			s, err = os.Create(*path)


### PR DESCRIPTION
Assuming you keep the binary in a directory that is in your path, or you make a link in your path so that you can run it from anywhere on the filesystem. As it is now, the templates folder is created and the services.json is downloaded in every location you run the program from. This pr fixes that and `./templates/services.json` is always kept where the binary is. Example follows:

Binary location:
```
/root/Tools/misconfig-mapper/misconfig-mapper
/usr/bin/misconfig-mapper -> /root/Tools/misconfig-mapper/misconfig-mapper (link)
```
Workplace directory structure:
```
/root/Bounties/bountya
/root/Bounties/bountyb
/root/Bounties/bountyc
```

I can run `misconfig-mapper` from any bounty location, however a new `./templates/services.json` gets created in each one. With the fixes above, the program always looks for `./templates/services.json` in the actual binary location so that would be `/root/Tools/misconfig-mapper/templates/services.json`. Sames goes for updates.