### PR TITLE
Feature: make templates directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Usage of ./misconfig-mapper:
     	Only check for existing instances (and skip checks for potential security misconfigurations). (default "false")
   -target string
     	Specify your target domain name or company/organization name: "intigriti.com" or "intigriti" (files are also accepted)
+  -templates string
+        Specify the templates folder location (default "./templates")
   -timeout int
     	Specify a timeout for each request sent in milliseconds. (default 7000)
   -update-templates

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ var suffixes = []string{
 	"prod",
 	"internal",
 	"dev",
-	"developement",
+	"development",
 	"devops",
 	"logs",
 	"logging",


### PR DESCRIPTION
This allows you to:

```shell
% go run main.go -update-templates -templates=templates3/
[+] Info: Pulling latest services and saving in templates3/services.json
[+] Info: Creating templates directory...
[+] Info: Successfully pulled the latest templates!
```