### PR TITLE
feat: add jsonlines output, quiet mode, errors to stderr, multi service select

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,11 +47,11 @@ type Service struct {
 }
 
 type Result struct {
-	URL        string  // Result URL
-	Exists     bool    // Used to report back in case the instance exists
-	Vulnerable bool    // Used to report back in case the instance is vulnerable
-	ServiceId  string  // Service ID
-	Service    Service // Service struct
+	URL        string  `json:"url"`        // Result URL
+	Exists     bool    `json:"exists"`     // Used to report back in case the instance exists
+	Vulnerable bool    `json:"vulnerable"` // Used to report back in case the instance is vulnerable
+	ServiceId  string  `json:"serviceid"`  // Service ID
+	Service    Service `json:"service"`    // Service struct
 }
 
 type RequestContext struct {
@@ -61,6 +61,7 @@ type RequestContext struct {
 	MaxRedirects int
 	Verbose      bool
 	Quiet        bool
+	JSONLines    bool
 }
 
 /* TYPES/ */
@@ -415,6 +416,18 @@ func checkResponse(result *Result, service *Service, r *RequestContext) {
 }
 
 func handleResult(result *Result, reqCTX *RequestContext, width int) {
+
+	if reqCTX.JSONLines {
+		d, err := json.Marshal(result)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to marshal result %v", err)
+			return
+		}
+
+		fmt.Println(string(d))
+		return
+	}
+
 	fmt.Println(strings.Repeat("-", width))
 
 	if reqCTX.SkipChecks {
@@ -502,6 +515,7 @@ func main() {
 	listServicesFlag := flag.Bool("list-services", false, "Print all services with their associated IDs")
 	templatesPath := flag.String("templates", "./templates", "Specify the templates folder location")
 	updateServicesFlag := flag.Bool("update-templates", false, "Pull the latest templates & update your current services.json file")
+	jsonLinesFlag := flag.Bool("output-json", false, "Print json lines instead")
 	verboseFlag := flag.Bool("verbose", false, "Print verbose messages")
 	quietFlag := flag.Bool("quiet", false, "Only output positive detections")
 
@@ -518,6 +532,7 @@ func main() {
 		MaxRedirects: *maxRedirectsFlag,
 		Verbose:      *verboseFlag,
 		Quiet:        *quietFlag,
+		JSONLines:    *jsonLinesFlag,
 	}
 
 	// Derrive terminal width

--- a/main.go
+++ b/main.go
@@ -257,7 +257,7 @@ func returnPossibleTargets(target string) []string {
 	return possibleTargets
 }
 
-func getTemplate(id string, services []Service) interface{} {
+func getTemplate(id string, services []Service) []Service {
 	var s []Service
 
 	for _, x := range services {
@@ -566,17 +566,17 @@ func main() {
 		selectedServices = services
 	} else {
 		s := getTemplate(service, services)
-		if s == nil || len(s.([]Service)) < 1 {
+		if s == nil || len(s) < 1 {
 			fmt.Printf("[-] Error: Service ID \"%v\" does not match any integrated service!\n\nAvailable Services:\n", service)
 			printServices(services, reqCTX.Verbose, width)
 			return
 		}
 
 		if reqCTX.Verbose {
-			fmt.Printf("[+] %v Services selected!\n", len(s.([]Service)))
+			fmt.Printf("[+] %v Services selected!\n", len(s))
 		}
 
-		selectedServices = append(selectedServices, s.([]Service)...)
+		selectedServices = append(selectedServices, s...)
 	}
 
 	// Parse "skip-misconfiguration-checks" CLI flag

--- a/main.go
+++ b/main.go
@@ -257,12 +257,16 @@ func returnPossibleTargets(target string) []string {
 	return possibleTargets
 }
 
-func getTemplate(id string, services []Service) []Service {
+func getTemplate(ids string, services []Service) []Service {
 	var s []Service
 
+	parsed := strings.Split(ids, ",")
+
 	for _, x := range services {
-		if (fmt.Sprintf(`%v`, x.ID) == id) || (fmt.Sprintf(`%v`, x.Metadata.Service) == id) {
-			s = append(s, x)
+		for _, i := range parsed {
+			if (fmt.Sprintf(`%v`, x.ID) == i) || (fmt.Sprintf(`%v`, x.Metadata.Service) == i) {
+				s = append(s, x)
+			}
 		}
 	}
 
@@ -481,7 +485,7 @@ func processInput(fileName string, input *[]string) {
 
 func main() {
 	targetFlag := flag.String("target", "", "Specify your target domain name or company/organization name: \"intigriti.com\" or \"intigriti\" (files are also accepted)")
-	serviceFlag := flag.String("service", "0", "Specify the service ID you'd like to check for: \"0\" for Atlassian Jira Open Signups. Wildcards are also accepted to check for all services.")
+	serviceFlag := flag.String("service", "0", "Specify the service ID you'd like to check for. For example, \"0\" for Atlassian Jira Open Signups. Use comma seperated values for multiple (i.e. \"0,1\" for two services). Use * to check for all services.")
 	skipChecksFlag := flag.String("skip-misconfiguration-checks", "false", "Only check for existing instances (and skip checks for potential security misconfigurations).")
 	permutationsFlag := flag.String("permutations", "true", "Enable permutations and look for several other keywords of your target.")
 	requestHeadersFlag := flag.String("headers", "", "Specify request headers to send with requests (separate each header with a double semi-colon: \"User-Agent: xyz;; Cookie: xyz...;;\")")


### PR DESCRIPTION
This PR adds a few things:

- Change the generic `interface{}` used to rather return a `Service`
- Add the ability to select multiple services to scan. i.e., `-service "0,1,2"`
- Ensure all errors write to `stderr` instead of clobbering `stdout`
- Add `-quiet` flag to not report non-vulnerable results
- Add `-output-json` to return results as JSON lines

I realise this a lot of changes. I made each change in a separate commit to try and make it obvious what changed.