### PR TITLE
Correct command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ _auto_completion_misconfig_mapper "$@"
 **Example 1:** Perform a scan to enumerate all misconfigured third-party services
 
 ```basic
-$ ./misconfig-mapper -target "yourcompanyname" -service 1 -delay 1000
+$ ./misconfig-mapper -target "yourcompanyname" -service "*" -delay 1000
 ```
 
 ![Example 1](.github/assets/images/example_1.png "Example 1")
@@ -125,7 +125,7 @@ $ ./misconfig-mapper -target "yourcompanyname" -service 1 -delay 1000
 **Example 2:** Perform a detection-only scan to enumerate all third-party services (without checking for any misconfigurations)
 
 ```bash
-$ ./misconfig-mapper -target "yourcompanyname" -service 1 -skip-misconfiguration-checks true
+$ ./misconfig-mapper -target "yourcompanyname" -service "*" -skip-misconfiguration-checks true
 ```
 
 ![Example 2](.github/assets/images/example_2.png "Example 2")


### PR DESCRIPTION
Service flag defaults to 0, to search all the wildcard (*) must be supplied (and generally quoted to prevent shell expansion).